### PR TITLE
fix: regex should treat newline like a regular char

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 // match[1] = visible text
 // match[2] = relevant escape code
 // match[3] = skippable escape code
-const ANSI_SEQUENCE = /^(.*?)(?:(\x1b\[[^m]+m|\x1b\]8;;.*?(?:\x1b\\|\u0007))|(\x1b\[\?[0-9]+[a-zA-Z]))/;
+const ANSI_SEQUENCE = /^([\s\S]*?)(?:(\x1b\[[^m]+m|\x1b\]8;;[\s\S]*?(?:\x1b\\|\u0007))|(\x1b\[\?[0-9]+[a-zA-Z]))/;
 
 const segmenter = new Intl.Segmenter(`en`, {granularity: `grapheme`});
 


### PR DESCRIPTION
`/./` is not the correct any-char regex
`/[\s\S]/` is

This lib broke on newlines

Fixes: #12 

An alternative is to add `/s` flag (but that is more intrusive and `engines` are not set)
Ref: https://github.com/tc39/proposal-regexp-dotall-flag